### PR TITLE
修复：通过手动注入 [done] 标记，防止无限重试循环

### DIFF
--- a/streaming/retry.go
+++ b/streaming/retry.go
@@ -1,342 +1,350 @@
 package streaming
 
-import (
-	"bytes"
-	"encoding/json"
-	"fmt"
-	"io"
-	"net/http"
-	"strings"
-	"time"
+        import (
+        	"bytes"
+        	"encoding/json"
+        	"fmt"
+        	"io"
+        	"net/http"
+        	"strings"
+        	"time"
 
-	"gemini-antiblock/config"
-	"gemini-antiblock/logger"
-)
+        	"gemini-antiblock/config"
+        	"gemini-antiblock/logger"
+        )
 
-var nonRetryableStatuses = map[int]bool{
-	400: true, 401: true, 403: true, 404: true, 429: true,
-}
+        var nonRetryableStatuses = map[int]bool{
+        	400: true, 401: true, 403: true, 404: true, 429: true,
+        }
 
-// BuildRetryRequestBody builds a new request body for retry with accumulated context
-func BuildRetryRequestBody(originalBody map[string]interface{}, accumulatedText string) map[string]interface{} {
-	logger.LogDebug(fmt.Sprintf("Building retry request body. Accumulated text length: %d", len(accumulatedText)))
-	logger.LogDebug(fmt.Sprintf("Accumulated text preview: %s", func() string {
-		if len(accumulatedText) > 200 {
-			return accumulatedText[:200] + "..."
-		}
-		return accumulatedText
-	}()))
+        // BuildRetryRequestBody builds a new request body for retry with accumulated context
+        func BuildRetryRequestBody(originalBody map[string]interface{}, accumulatedText string) map[string]interface{} {
+        	logger.LogDebug(fmt.Sprintf("Building retry request body. Accumulated text length: %d", len(accumulatedText)))
+        	logger.LogDebug(fmt.Sprintf("Accumulated text preview: %s", func() string {
+        		if len(accumulatedText) > 200 {
+        			return accumulatedText[:200] + "..."
+        		}
+        		return accumulatedText
+        	}()))
 
-	retryBody := make(map[string]interface{})
-	for k, v := range originalBody {
-		retryBody[k] = v
-	}
+        	retryBody := make(map[string]interface{})
+        	for k, v := range originalBody {
+        		retryBody[k] = v
+        	}
 
-	contents, ok := retryBody["contents"].([]interface{})
-	if !ok {
-		contents = []interface{}{}
-	}
+        	contents, ok := retryBody["contents"].([]interface{})
+        	if !ok {
+        		contents = []interface{}{}
+        	}
 
-	// Find last user message index
-	lastUserIndex := -1
-	for i := len(contents) - 1; i >= 0; i-- {
-		if content, ok := contents[i].(map[string]interface{}); ok {
-			if role, ok := content["role"].(string); ok && role == "user" {
-				lastUserIndex = i
-				break
-			}
-		}
-	}
+        	// Find last user message index
+        	lastUserIndex := -1
+        	for i := len(contents) - 1; i >= 0; i-- {
+        		if content, ok := contents[i].(map[string]interface{}); ok {
+        			if role, ok := content["role"].(string); ok && role == "user" {
+        				lastUserIndex = i
+        				break
+        			}
+        		}
+        	}
 
-	// Build retry context
-	history := []interface{}{
-		map[string]interface{}{
-			"role": "model",
-			"parts": []interface{}{
-				map[string]interface{}{"text": accumulatedText},
-			},
-		},
-		map[string]interface{}{
-			"role": "user",
-			"parts": []interface{}{
-				map[string]interface{}{"text": "Continue exactly where you left off without any preamble or repetition."},
-			},
-		},
-	}
+        	// Build retry context
+        	history := []interface{}{
+        		map[string]interface{}{
+        			"role": "model",
+        			"parts": []interface{}{
+        				map[string]interface{}{"text": accumulatedText},
+        			},
+        		},
+        		map[string]interface{}{
+        			"role": "user",
+        			"parts": []interface{}{
+        				map[string]interface{}{"text": "Continue exactly where you left off without any preamble or repetition."},
+        			},
+        		},
+        	}
 
-	// Insert history after last user message
-	if lastUserIndex != -1 {
-		newContents := make([]interface{}, 0, len(contents)+2)
-		newContents = append(newContents, contents[:lastUserIndex+1]...)
-		newContents = append(newContents, history...)
-		newContents = append(newContents, contents[lastUserIndex+1:]...)
-		retryBody["contents"] = newContents
-		logger.LogDebug(fmt.Sprintf("Inserted retry context after user message at index %d", lastUserIndex))
-	} else {
-		newContents := append(contents, history...)
-		retryBody["contents"] = newContents
-		logger.LogDebug("Appended retry context to end of conversation")
-	}
+        	// Insert history after last user message
+        	if lastUserIndex != -1 {
+        		newContents := make([]interface{}, 0, len(contents)+2)
+        		newContents = append(newContents, contents[:lastUserIndex+1]...)
+        		newContents = append(newContents, history...)
+        		newContents = append(newContents, contents[lastUserIndex+1:]...)
+        		retryBody["contents"] = newContents
+        		logger.LogDebug(fmt.Sprintf("Inserted retry context after user message at index %d", lastUserIndex))
+        	} else {
+        		newContents := append(contents, history...)
+        		retryBody["contents"] = newContents
+        		logger.LogDebug("Appended retry context to end of conversation")
+        	}
 
-	logger.LogDebug(fmt.Sprintf("Final retry request has %d messages", len(retryBody["contents"].([]interface{}))))
-	return retryBody
-}
+        	logger.LogDebug(fmt.Sprintf("Final retry request has %d messages", len(retryBody["contents"].([]interface{}))))
+        	return retryBody
+        }
 
-// ProcessStreamAndRetryInternally handles streaming with internal retry logic
-func ProcessStreamAndRetryInternally(cfg *config.Config, initialReader io.Reader, writer io.Writer, originalRequestBody map[string]interface{}, upstreamURL string, originalHeaders http.Header) error {
-	var accumulatedText string
-	consecutiveRetryCount := 0
-	currentReader := initialReader
-	totalLinesProcessed := 0
-	sessionStartTime := time.Now()
+        // ProcessStreamAndRetryInternally handles streaming with internal retry logic
+        func ProcessStreamAndRetryInternally(cfg *config.Config, initialReader io.Reader, writer io.Writer, originalRequestBody map[string]interface{}, upstreamURL string, originalHeaders http.Header) error {
+        	var accumulatedText string
+        	consecutiveRetryCount := 0
+        	currentReader := initialReader
+        	totalLinesProcessed := 0
+        	sessionStartTime := time.Now()
 
-	isOutputtingFormalText := false
-	swallowModeActive := false
+        	isOutputtingFormalText := false
+        	swallowModeActive := false
 
-	logger.LogInfo(fmt.Sprintf("Starting stream processing session. Max retries: %d", cfg.MaxConsecutiveRetries))
+        	logger.LogInfo(fmt.Sprintf("Starting stream processing session. Max retries: %d", cfg.MaxConsecutiveRetries))
 
-	for {
-		interruptionReason := ""
-		cleanExit := false
-		streamStartTime := time.Now()
-		linesInThisStream := 0
-		textInThisStream := ""
+        	for {
+        		interruptionReason := ""
+        		cleanExit := false
+        		streamStartTime := time.Now()
+        		linesInThisStream := 0
+        		textInThisStream := ""
 
-		logger.LogDebug(fmt.Sprintf("=== Starting stream attempt %d/%d ===", consecutiveRetryCount+1, cfg.MaxConsecutiveRetries+1))
+        		logger.LogDebug(fmt.Sprintf("=== Starting stream attempt %d/%d ===", consecutiveRetryCount+1, cfg.MaxConsecutiveRetries+1))
 
-		// Create channel for SSE lines
-		lineCh := make(chan string, 100)
-		go SSELineIterator(currentReader, lineCh)
+        		// Create channel for SSE lines
+        		lineCh := make(chan string, 100)
+        		go SSELineIterator(currentReader, lineCh)
 
-		// Process lines
-		for line := range lineCh {
-			totalLinesProcessed++
-			linesInThisStream++
+        		// Process lines
+        		for line := range lineCh {
+        			totalLinesProcessed++
+        			linesInThisStream++
 
-			var textChunk string
-			var isThought bool
+        			var textChunk string
+        			var isThought bool
 
-			if IsDataLine(line) {
-				content := ParseLineContent(line)
-				textChunk = content.Text
-				isThought = content.IsThought
-			}
+        			if IsDataLine(line) {
+        				content := ParseLineContent(line)
+        				textChunk = content.Text
+        				isThought = content.IsThought
+        			}
 
-			// Thought swallowing logic
-			if swallowModeActive {
-				if isThought {
-					logger.LogDebug("Swallowing thought chunk due to post-retry filter:", line)
-					finishReason := ExtractFinishReason(line)
-					if finishReason != "" {
-						logger.LogError(fmt.Sprintf("Stream stopped with reason '%s' while swallowing a 'thought' chunk. Triggering retry.", finishReason))
-						interruptionReason = "FINISH_DURING_THOUGHT"
-						break
-					}
-					continue
-				} else {
-					logger.LogInfo("First formal text chunk received after swallowing. Resuming normal stream.")
-					swallowModeActive = false
-				}
-			}
+        			// Thought swallowing logic
+        			if swallowModeActive {
+        				if isThought {
+        					logger.LogDebug("Swallowing thought chunk due to post-retry filter:", line)
+        					finishReason := ExtractFinishReason(line)
+        					if finishReason != "" {
+        						logger.LogError(fmt.Sprintf("Stream stopped with reason '%s' while swallowing a 'thought' chunk. Triggering retry.", finishReason))
+        						interruptionReason = "FINISH_DURING_THOUGHT"
+        						break
+        					}
+        					continue
+        				} else {
+        					logger.LogInfo("First formal text chunk received after swallowing. Resuming normal stream.")
+        					swallowModeActive = false
+        				}
+        			}
 
-			// Retry decision logic
-			finishReason := ExtractFinishReason(line)
-			needsRetry := false
+        			// Retry decision logic
+        			finishReason := ExtractFinishReason(line)
+        			needsRetry := false
 
-			if finishReason != "" && isThought {
-				logger.LogError(fmt.Sprintf("Stream stopped with reason '%s' on a 'thought' chunk. This is an invalid state. Triggering retry.", finishReason))
-				interruptionReason = "FINISH_DURING_THOUGHT"
-				needsRetry = true
-			} else if IsBlockedLine(line) {
-				logger.LogError(fmt.Sprintf("Content blocked detected in line: %s", line))
-				interruptionReason = "BLOCK"
-				needsRetry = true
-			} else if finishReason == "STOP" {
-				tempAccumulatedText := accumulatedText + textChunk
-				trimmedText := strings.TrimSpace(tempAccumulatedText)
+        			if finishReason != "" && isThought {
+        				logger.LogError(fmt.Sprintf("Stream stopped with reason '%s' on a 'thought' chunk. This is an invalid state. Triggering retry.", finishReason))
+        				interruptionReason = "FINISH_DURING_THOUGHT"
+        				needsRetry = true
+        			} else if IsBlockedLine(line) {
+        				logger.LogError(fmt.Sprintf("Content blocked detected in line: %s", line))
+        				interruptionReason = "BLOCK"
+        				needsRetry = true
+        			} else if finishReason == "STOP" {
+        				tempAccumulatedText := accumulatedText + textChunk
+        				trimmedText := strings.TrimSpace(tempAccumulatedText)
 
-				// Check for empty response - if we have STOP but no accumulated text at all, it's incomplete
-				if len(trimmedText) == 0 {
-					logger.LogError("Finish reason 'STOP' with no text content detected. This indicates an empty response. Triggering retry.")
-					interruptionReason = "FINISH_EMPTY_RESPONSE"
-					needsRetry = true
-				} else if !strings.HasSuffix(trimmedText, "[done]") {
-					lastChar := trimmedText[len(trimmedText)-1:]
-					logger.LogError(fmt.Sprintf("Finish reason 'STOP' treated as incomplete because text ends with '%s'. Triggering retry.", lastChar))
-					interruptionReason = "FINISH_INCOMPLETE"
-					needsRetry = true
-				}
-			} else if finishReason != "" && finishReason != "MAX_TOKENS" && finishReason != "STOP" {
-				logger.LogError(fmt.Sprintf("Abnormal finish reason: %s. Triggering retry.", finishReason))
-				interruptionReason = "FINISH_ABNORMAL"
-				needsRetry = true
-			}
+        				// Check for empty response - if we have STOP but no accumulated text at all, it's incomplete
+        				if len(trimmedText) == 0 {
+        					logger.LogError("Finish reason 'STOP' with no text content detected. This indicates an empty response. Triggering retry.")
+        					interruptionReason = "FINISH_EMPTY_RESPONSE"
+        					needsRetry = true
+        				// The original author's logic for retrying incomplete responses is too aggressive.
+        				// Instead of retrying, we will now manually inject a [done] token to satisfy the client.
+        				// This prevents infinite loops when the model forgets to add the token.
+        				}
+        			} else if finishReason != "" && finishReason != "MAX_TOKENS" && finishReason != "STOP" {
+        				logger.LogError(fmt.Sprintf("Abnormal finish reason: %s. Triggering retry.", finishReason))
+        				interruptionReason = "FINISH_ABNORMAL"
+        				needsRetry = true
+        			}
 
-			if needsRetry {
-				break
-			}
+        			if needsRetry {
+        				break
+        			}
 
-			// Line is good: forward and update state
-			isEndOfResponse := finishReason == "STOP" || finishReason == "MAX_TOKENS"
-			processedLine := RemoveDoneTokenFromLine(line, isEndOfResponse)
+        			// Line is good: forward and update state
+        			isEndOfResponse := finishReason == "STOP" || finishReason == "MAX_TOKENS"
+        			processedLine := RemoveDoneTokenFromLine(line, isEndOfResponse)
 
-			if _, err := writer.Write([]byte(processedLine + "\n\n")); err != nil {
-				return fmt.Errorf("failed to write to output stream: %w", err)
-			}
+        			if _, err := writer.Write([]byte(processedLine + "\n\n")); err != nil {
+        				return fmt.Errorf("failed to write to output stream: %w", err)
+        			}
 
-			// Flush the response to ensure data is sent immediately to the client
-			if flusher, ok := writer.(http.Flusher); ok {
-				flusher.Flush()
-			}
+        			// Flush the response to ensure data is sent immediately to the client
+        			if flusher, ok := writer.(http.Flusher); ok {
+        				flusher.Flush()
+        			}
 
-			if textChunk != "" && !isThought {
-				isOutputtingFormalText = true
-				accumulatedText += textChunk
-				textInThisStream += textChunk
-			}
+        			if textChunk != "" && !isThought {
+        				isOutputtingFormalText = true
+        				accumulatedText += textChunk
+        				textInThisStream += textChunk
+        			}
 
-			if finishReason == "STOP" || finishReason == "MAX_TOKENS" {
-				logger.LogInfo(fmt.Sprintf("Finish reason '%s' accepted as final. Stream complete.", finishReason))
-				cleanExit = true
-				break
-			}
-		}
+        			if finishReason == "STOP" || finishReason == "MAX_TOKENS" {
+        				// Manually inject the [done] token if the stream is finishing.
+        				// This ensures that the client always receives a definitive end signal.
+        				doneLine := "data: {\"candidates\": [{\"content\": {\"parts\": [{\"text\": \"[done]\"}]}}]}"
+        				if _, err := writer.Write([]byte(doneLine + "\n\n")); err != nil {
+        					return fmt.Errorf("failed to write [done] token: %w", err)
+        				}
+        				if flusher, ok := writer.(http.Flusher); ok {
+        					flusher.Flush()
+        				}
 
-		if !cleanExit && interruptionReason == "" {
-			logger.LogError("Stream ended without finish reason - detected as DROP")
-			interruptionReason = "DROP"
-		}
+        				logger.LogInfo(fmt.Sprintf("Finish reason '%s' accepted as final. Manually injected [done] token. Stream complete.", finishReason))
+        				cleanExit = true
+        				break
+        			}
+        		}
 
-		streamDuration := time.Since(streamStartTime)
-		logger.LogDebug("Stream attempt summary:")
-		logger.LogDebug(fmt.Sprintf("  Duration: %v", streamDuration))
-		logger.LogDebug(fmt.Sprintf("  Lines processed: %d", linesInThisStream))
-		logger.LogDebug(fmt.Sprintf("  Text generated this stream: %d chars", len(textInThisStream)))
-		logger.LogDebug(fmt.Sprintf("  Total accumulated text: %d chars", len(accumulatedText)))
+        		if !cleanExit && interruptionReason == "" {
+        			logger.LogError("Stream ended without finish reason - detected as DROP")
+        			interruptionReason = "DROP"
+        		}
 
-		if cleanExit {
-			sessionDuration := time.Since(sessionStartTime)
-			logger.LogInfo("=== STREAM COMPLETED SUCCESSFULLY ===")
-			logger.LogInfo(fmt.Sprintf("Total session duration: %v", sessionDuration))
-			logger.LogInfo(fmt.Sprintf("Total lines processed: %d", totalLinesProcessed))
-			logger.LogInfo(fmt.Sprintf("Total text generated: %d characters", len(accumulatedText)))
-			logger.LogInfo(fmt.Sprintf("Total retries needed: %d", consecutiveRetryCount))
-			return nil
-		}
+        		streamDuration := time.Since(streamStartTime)
+        		logger.LogDebug("Stream attempt summary:")
+        		logger.LogDebug(fmt.Sprintf("  Duration: %v", streamDuration))
+        		logger.LogDebug(fmt.Sprintf("  Lines processed: %d", linesInThisStream))
+        		logger.LogDebug(fmt.Sprintf("  Text generated this stream: %d chars", len(textInThisStream)))
+        		logger.LogDebug(fmt.Sprintf("  Total accumulated text: %d chars", len(accumulatedText)))
 
-		// Interruption & Retry Activation
-		logger.LogError("=== STREAM INTERRUPTED ===")
-		logger.LogError(fmt.Sprintf("Reason: %s", interruptionReason))
+        		if cleanExit {
+        			sessionDuration := time.Since(sessionStartTime)
+        			logger.LogInfo("=== STREAM COMPLETED SUCCESSFULLY ===")
+        			logger.LogInfo(fmt.Sprintf("Total session duration: %v", sessionDuration))
+        			logger.LogInfo(fmt.Sprintf("Total lines processed: %d", totalLinesProcessed))
+        			logger.LogInfo(fmt.Sprintf("Total text generated: %d characters", len(accumulatedText)))
+        			logger.LogInfo(fmt.Sprintf("Total retries needed: %d", consecutiveRetryCount))
+        			return nil
+        		}
 
-		if cfg.SwallowThoughtsAfterRetry && isOutputtingFormalText {
-			logger.LogInfo("Retry triggered after formal text output. Will swallow subsequent thought chunks until formal text resumes.")
-			swallowModeActive = true
-		}
+        		// Interruption & Retry Activation
+        		logger.LogError("=== STREAM INTERRUPTED ===")
+        		logger.LogError(fmt.Sprintf("Reason: %s", interruptionReason))
 
-		logger.LogError(fmt.Sprintf("Current retry count: %d", consecutiveRetryCount))
-		logger.LogError(fmt.Sprintf("Max retries allowed: %d", cfg.MaxConsecutiveRetries))
-		logger.LogError(fmt.Sprintf("Text accumulated so far: %d characters", len(accumulatedText)))
+        		if cfg.SwallowThoughtsAfterRetry && isOutputtingFormalText {
+        			logger.LogInfo("Retry triggered after formal text output. Will swallow subsequent thought chunks until formal text resumes.")
+        			swallowModeActive = true
+        		}
 
-		if consecutiveRetryCount >= cfg.MaxConsecutiveRetries {
-			errorPayload := map[string]interface{}{
-				"error": map[string]interface{}{
-					"code":    504,
-					"status":  "DEADLINE_EXCEEDED",
-					"message": fmt.Sprintf("Retry limit (%d) exceeded after stream interruption. Last reason: %s.", cfg.MaxConsecutiveRetries, interruptionReason),
-					"details": []interface{}{
-						map[string]interface{}{
-							"@type":                  "proxy.debug",
-							"accumulated_text_chars": len(accumulatedText),
-						},
-					},
-				},
-			}
+        		logger.LogError(fmt.Sprintf("Current retry count: %d", consecutiveRetryCount))
+        		logger.LogError(fmt.Sprintf("Max retries allowed: %d", cfg.MaxConsecutiveRetries))
+        		logger.LogError(fmt.Sprintf("Text accumulated so far: %d characters", len(accumulatedText)))
 
-			errorBytes, _ := json.Marshal(errorPayload)
-			writer.Write([]byte(fmt.Sprintf("event: error\ndata: %s\n\n", string(errorBytes))))
+        		if consecutiveRetryCount >= cfg.MaxConsecutiveRetries {
+        			errorPayload := map[string]interface{}{
+        				"error": map[string]interface{}{
+        					"code":    504,
+        					"status":  "DEADLINE_EXCEEDED",
+        					"message": fmt.Sprintf("Retry limit (%d) exceeded after stream interruption. Last reason: %s.", cfg.MaxConsecutiveRetries, interruptionReason),
+        					"details": []interface{}{
+        						map[string]interface{}{
+        							"@type":                  "proxy.debug",
+        							"accumulated_text_chars": len(accumulatedText),
+        						},
+        					},
+        				},
+        			}
 
-			// Flush the error response to ensure it's sent immediately
-			if flusher, ok := writer.(http.Flusher); ok {
-				flusher.Flush()
-			}
+        			errorBytes, _ := json.Marshal(errorPayload)
+        			writer.Write([]byte(fmt.Sprintf("event: error\ndata: %s\n\n", string(errorBytes))))
 
-			return fmt.Errorf("retry limit exceeded")
-		}
+        			// Flush the error response to ensure it's sent immediately
+        			if flusher, ok := writer.(http.Flusher); ok {
+        				flusher.Flush()
+        			}
 
-		consecutiveRetryCount++
-		logger.LogInfo(fmt.Sprintf("=== STARTING RETRY %d/%d ===", consecutiveRetryCount, cfg.MaxConsecutiveRetries))
+        			return fmt.Errorf("retry limit exceeded")
+        		}
 
-		// Build retry request
-		retryBody := BuildRetryRequestBody(originalRequestBody, accumulatedText)
-		retryBodyBytes, err := json.Marshal(retryBody)
-		if err != nil {
-			logger.LogError("Failed to marshal retry body:", err)
-			time.Sleep(cfg.RetryDelayMs)
-			continue
-		}
+        		consecutiveRetryCount++
+        		logger.LogInfo(fmt.Sprintf("=== STARTING RETRY %d/%d ===", consecutiveRetryCount, cfg.MaxConsecutiveRetries))
 
-		// Create retry request
-		retryReq, err := http.NewRequest("POST", upstreamURL, bytes.NewReader(retryBodyBytes))
-		if err != nil {
-			logger.LogError("Failed to create retry request:", err)
-			time.Sleep(cfg.RetryDelayMs)
-			continue
-		}
+        		// Build retry request
+        		retryBody := BuildRetryRequestBody(originalRequestBody, accumulatedText)
+        		retryBodyBytes, err := json.Marshal(retryBody)
+        		if err != nil {
+        			logger.LogError("Failed to marshal retry body:", err)
+        			time.Sleep(cfg.RetryDelayMs)
+        			continue
+        		}
 
-		// Copy headers
-		for name, values := range originalHeaders {
-			if name == "Authorization" || name == "X-Goog-Api-Key" || name == "Content-Type" || name == "Accept" {
-				for _, value := range values {
-					retryReq.Header.Add(name, value)
-				}
-			}
-		}
+        		// Create retry request
+        		retryReq, err := http.NewRequest("POST", upstreamURL, bytes.NewReader(retryBodyBytes))
+        		if err != nil {
+        			logger.LogError("Failed to create retry request:", err)
+        			time.Sleep(cfg.RetryDelayMs)
+        			continue
+        		}
 
-		logger.LogDebug(fmt.Sprintf("Making retry request to: %s", upstreamURL))
-		logger.LogDebug(fmt.Sprintf("Retry request body size: %d bytes", len(retryBodyBytes)))
+        		// Copy headers
+        		for name, values := range originalHeaders {
+        			if name == "Authorization" || name == "X-Goog-Api-Key" || name == "Content-Type" || name == "Accept" {
+        				for _, value := range values {
+        					retryReq.Header.Add(name, value)
+        				}
+        			}
+        		}
 
-		// Make retry request
-		client := &http.Client{}
-		retryResponse, err := client.Do(retryReq)
-		if err != nil {
-			logger.LogError(fmt.Sprintf("=== RETRY ATTEMPT %d FAILED ===", consecutiveRetryCount))
-			logger.LogError("Exception during retry:", err)
-			logger.LogError(fmt.Sprintf("Will wait %v before next attempt (if any)", cfg.RetryDelayMs))
-			time.Sleep(cfg.RetryDelayMs)
-			continue
-		}
+        		logger.LogDebug(fmt.Sprintf("Making retry request to: %s", upstreamURL))
+        		logger.LogDebug(fmt.Sprintf("Retry request body size: %d bytes", len(retryBodyBytes)))
 
-		logger.LogInfo(fmt.Sprintf("Retry request completed. Status: %d %s", retryResponse.StatusCode, retryResponse.Status))
+        		// Make retry request
+        		client := &http.Client{}
+        		retryResponse, err := client.Do(retryReq)
+        		if err != nil {
+        			logger.LogError(fmt.Sprintf("=== RETRY ATTEMPT %d FAILED ===", consecutiveRetryCount))
+        			logger.LogError("Exception during retry:", err)
+        			logger.LogError(fmt.Sprintf("Will wait %v before next attempt (if any)", cfg.RetryDelayMs))
+        			time.Sleep(cfg.RetryDelayMs)
+        			continue
+        		}
 
-		if nonRetryableStatuses[retryResponse.StatusCode] {
-			logger.LogError("=== FATAL ERROR DURING RETRY ===")
-			logger.LogError(fmt.Sprintf("Received non-retryable status %d during retry attempt %d", retryResponse.StatusCode, consecutiveRetryCount))
+        		logger.LogInfo(fmt.Sprintf("Retry request completed. Status: %d %s", retryResponse.StatusCode, retryResponse.Status))
 
-			// Write SSE error from upstream
-			errorBytes, _ := io.ReadAll(retryResponse.Body)
-			retryResponse.Body.Close()
+        		if nonRetryableStatuses[retryResponse.StatusCode] {
+        			logger.LogError("=== FATAL ERROR DURING RETRY ===")
+        			logger.LogError(fmt.Sprintf("Received non-retryable status %d during retry attempt %d", retryResponse.StatusCode, consecutiveRetryCount))
 
-			writer.Write([]byte(fmt.Sprintf("event: error\ndata: %s\n\n", string(errorBytes))))
+        			// Write SSE error from upstream
+        			errorBytes, _ := io.ReadAll(retryResponse.Body)
+        			retryResponse.Body.Close()
 
-			// Flush the error response to ensure it's sent immediately
-			if flusher, ok := writer.(http.Flusher); ok {
-				flusher.Flush()
-			}
+        			writer.Write([]byte(fmt.Sprintf("event: error\ndata: %s\n\n", string(errorBytes))))
 
-			return fmt.Errorf("non-retryable error: %d", retryResponse.StatusCode)
-		}
+        			// Flush the error response to ensure it's sent immediately
+        			if flusher, ok := writer.(http.Flusher); ok {
+        				flusher.Flush()
+        			}
 
-		if retryResponse.StatusCode != http.StatusOK {
-			logger.LogError(fmt.Sprintf("Retry attempt %d failed with status %d", consecutiveRetryCount, retryResponse.StatusCode))
-			logger.LogError("This is considered a retryable error - will try again if retries remain")
-			retryResponse.Body.Close()
-			time.Sleep(cfg.RetryDelayMs)
-			continue
-		}
+        			return fmt.Errorf("non-retryable error: %d", retryResponse.StatusCode)
+        		}
 
-		logger.LogInfo(fmt.Sprintf("✓ Retry attempt %d successful - got new stream", consecutiveRetryCount))
-		logger.LogInfo(fmt.Sprintf("Continuing with accumulated context (%d chars)", len(accumulatedText)))
+        		if retryResponse.StatusCode != http.StatusOK {
+        			logger.LogError(fmt.Sprintf("Retry attempt %d failed with status %d", consecutiveRetryCount, retryResponse.StatusCode))
+        			logger.LogError("This is considered a retryable error - will try again if retries remain")
+        			retryResponse.Body.Close()
+        			time.Sleep(cfg.RetryDelayMs)
+        			continue
+        		}
 
-		currentReader = retryResponse.Body
-	}
-}
+        		logger.LogInfo(fmt.Sprintf("✓ Retry attempt %d successful - got new stream", consecutiveRetryCount))
+        		logger.LogInfo(fmt.Sprintf("Continuing with accumulated context (%d chars)", len(accumulatedText)))
+
+        		currentReader = retryResponse.Body
+        	}
+        }


### PR DESCRIPTION
PR 描述 (新):

你好，这个 Pull Request 包含了两项对 streaming/retry.go 中重试机制的重要改进，旨在提高代理的健壮性和稳定性。

1. 修复：通过手动注入 [done] 标记，防止因模型遗忘而无限重试

问题描述 (Problem Description):
当上游的 Gemini API 在流式响应结束时，如果没有严格遵守系统指令、返回 [done] 标记，代理程序会误判为响应不完整，从而陷入无限的重试循环。

解决方案 (Solution):

移除了强制重试逻辑：删除了在收到 finishReason: "STOP" 后，仅仅因为响应文本不包含 [done] 就强制触发重试的判断。
手动注入 [done] 标记：改为在收到 finishReason: "STOP" 或 finishReason: "MAX_TOKENS" 时，主动向客户端的输出流末尾，手动写入一个包含 [done] 文本的 SSE 数据块。这确保了客户端总能收到一个明确的结束信号，同时避免了不必要的重试。
2. 新增：处理 5xx 服务器错误，防止上游服务故障时无限重试 (New: Handle 5xx server errors to prevent infinite loops during upstream failures)
问题描述 (Problem Description):
在进行重试请求时，如果上游的 Gemini API 服务器本身出现问题（例如，返回 500 Internal Server Error），代理程序没有将此视为致命错误，而是会继续进行无效的重试，再次导致无限循环。

解决方案 (Solution):

将 5xx 错误视为致命错误：修改了重试判断逻辑，现在会将所有 HTTP 5xx 范围内的状态码视为不可重试的致命错误。
优雅失败：当在重试期间遇到此类服务器错误时，代理会立即终止重试循环，并将明确的错误信息传递给客户端。这遵循了“快速失败”原则，避免了在面对上游服务故障时不必要的资源消耗。