### PR TITLE
修复了maxtoken处理逻辑

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,7 +7,7 @@ UPSTREAM_URL_BASE=https://generativelanguage.googleapis.com
 MAX_CONSECUTIVE_RETRIES=100
 
 # Enable debug logging (true/false)
-DEBUG_MODE=true
+DEBUG_MODE=false
 
 # Delay between retry attempts in milliseconds
 RETRY_DELAY_MS=750
@@ -19,7 +19,9 @@ SWALLOW_THOUGHTS_AFTER_RETRY=true
 PORT=8080
 
 # Rate limiting configuration
+# Enable or disable rate limiting (true/false)
+ENABLE_RATE_LIMIT=false
 # Maximum number of requests per window for a single key
-RATE_LIMIT_COUNT=3
+RATE_LIMIT_COUNT=10
 # The time window in seconds for the rate limit
 RATE_LIMIT_WINDOW_SECONDS=60

--- a/.env.example
+++ b/.env.example
@@ -17,3 +17,9 @@ SWALLOW_THOUGHTS_AFTER_RETRY=true
 
 # Server port
 PORT=8080
+
+# Rate limiting configuration
+# Maximum number of requests per window for a single key
+RATE_LIMIT_COUNT=3
+# The time window in seconds for the rate limit
+RATE_LIMIT_WINDOW_SECONDS=60

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,9 @@ RUN go mod download
 COPY . .
 
 # 构建应用
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build \
+ARG TARGETOS
+ARG TARGETARCH
+RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build \
     -ldflags='-w -s -extldflags "-static"' \
     -a -installsuffix cgo \
     -o gemini-antiblock .

--- a/config/config.go
+++ b/config/config.go
@@ -14,6 +14,7 @@ type Config struct {
 	RetryDelayMs              time.Duration
 	SwallowThoughtsAfterRetry bool
 	Port                      string
+	EnableRateLimit           bool
 	RateLimitCount            int
 	RateLimitWindowSeconds    int
 }
@@ -27,7 +28,8 @@ func LoadConfig() *Config {
 		RetryDelayMs:              time.Duration(getEnvInt("RETRY_DELAY_MS", 750)) * time.Millisecond,
 		SwallowThoughtsAfterRetry: getEnvBool("SWALLOW_THOUGHTS_AFTER_RETRY", true),
 		Port:                      getEnvString("PORT", "8080"),
-		RateLimitCount:            getEnvInt("RATE_LIMIT_COUNT", 3),
+		EnableRateLimit:           getEnvBool("ENABLE_RATE_LIMIT", false),
+		RateLimitCount:            getEnvInt("RATE_LIMIT_COUNT", 10),
 		RateLimitWindowSeconds:    getEnvInt("RATE_LIMIT_WINDOW_SECONDS", 60),
 	}
 }

--- a/config/config.go
+++ b/config/config.go
@@ -14,6 +14,8 @@ type Config struct {
 	RetryDelayMs              time.Duration
 	SwallowThoughtsAfterRetry bool
 	Port                      string
+	RateLimitCount            int
+	RateLimitWindowSeconds    int
 }
 
 // LoadConfig loads configuration from environment variables
@@ -25,6 +27,8 @@ func LoadConfig() *Config {
 		RetryDelayMs:              time.Duration(getEnvInt("RETRY_DELAY_MS", 750)) * time.Millisecond,
 		SwallowThoughtsAfterRetry: getEnvBool("SWALLOW_THOUGHTS_AFTER_RETRY", true),
 		Port:                      getEnvString("PORT", "8080"),
+		RateLimitCount:            getEnvInt("RATE_LIMIT_COUNT", 3),
+		RateLimitWindowSeconds:    getEnvInt("RATE_LIMIT_WINDOW_SECONDS", 60),
 	}
 }
 

--- a/handlers/ratelimiter.go
+++ b/handlers/ratelimiter.go
@@ -1,0 +1,68 @@
+package handlers
+
+import (
+	"sync"
+	"time"
+)
+
+// RateLimiter controls request rates on a per-key basis.
+type RateLimiter struct {
+	mutex   sync.Mutex
+	clients map[string][]time.Time // Map from API key to its request timestamps
+	limit   int
+	window  time.Duration
+}
+
+// NewRateLimiter creates a new RateLimiter.
+func NewRateLimiter(limit int, window time.Duration) *RateLimiter {
+	return &RateLimiter{
+		clients: make(map[string][]time.Time),
+		limit:   limit,
+		window:  window,
+	}
+}
+
+// Wait enforces the rate limit for a given key, waiting if necessary.
+func (l *RateLimiter) Wait(apiKey string) {
+	// Loop to handle the case where we wake up but another goroutine gets the slot.
+	for {
+		l.mutex.Lock()
+
+		now := time.Now()
+		cutoff := now.Add(-l.window)
+
+		// Get timestamps for the current key, cleaning up old ones.
+		timestamps, _ := l.clients[apiKey]
+		firstValidIndex := 0
+		for i, ts := range timestamps {
+			if !ts.Before(cutoff) {
+				firstValidIndex = i
+				break
+			}
+			if i == len(timestamps)-1 {
+				firstValidIndex = i + 1
+			}
+		}
+		timestamps = timestamps[firstValidIndex:]
+
+		// If the limit is not reached, allow the request and record it.
+		if len(timestamps) < l.limit {
+			l.clients[apiKey] = append(timestamps, now)
+			l.mutex.Unlock()
+			return // Allowed, exit.
+		}
+
+		// If the limit is reached, calculate the necessary wait time.
+		oldestTimestamp := timestamps[0]
+		waitUntil := oldestTimestamp.Add(l.window)
+		waitTime := time.Until(waitUntil)
+
+		// Unlock the mutex while waiting to not block other keys.
+		l.mutex.Unlock()
+
+		if waitTime > 0 {
+			time.Sleep(waitTime)
+		}
+		// After waiting, loop again to re-check the conditions.
+	}
+}

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"time"
 
 	"github.com/gorilla/mux"
 	"github.com/joho/godotenv"
@@ -34,8 +35,13 @@ func main() {
 	logger.LogInfo(fmt.Sprintf("Swallow thoughts after retry: %t", cfg.SwallowThoughtsAfterRetry))
 	logger.LogInfo(fmt.Sprintf("Server port: %s", cfg.Port))
 
+	// Create rate limiter from config
+	rateLimitWindow := time.Duration(cfg.RateLimitWindowSeconds) * time.Second
+	rateLimiter := handlers.NewRateLimiter(cfg.RateLimitCount, rateLimitWindow)
+	logger.LogInfo(fmt.Sprintf("Rate limiting enabled: %d requests per %v per key", cfg.RateLimitCount, rateLimitWindow))
+
 	// Create proxy handler
-	proxyHandler := handlers.NewProxyHandler(cfg)
+	proxyHandler := handlers.NewProxyHandler(cfg, rateLimiter)
 
 	// Set up routes
 	router := mux.NewRouter()

--- a/main.go
+++ b/main.go
@@ -38,7 +38,9 @@ func main() {
 	// Create rate limiter from config
 	rateLimitWindow := time.Duration(cfg.RateLimitWindowSeconds) * time.Second
 	rateLimiter := handlers.NewRateLimiter(cfg.RateLimitCount, rateLimitWindow)
-	logger.LogInfo(fmt.Sprintf("Rate limiting enabled: %d requests per %v per key", cfg.RateLimitCount, rateLimitWindow))
+	if cfg.EnableRateLimit {
+		logger.LogInfo(fmt.Sprintf("Rate limiting enabled: %d requests per %v per key", cfg.RateLimitCount, rateLimitWindow))
+	}
 
 	// Create proxy handler
 	proxyHandler := handlers.NewProxyHandler(cfg, rateLimiter)


### PR DESCRIPTION
原逻辑为：总输出长度超出65535token后截断
改为：总输出长度超出maxtoken后截断，客户端不输入则默认为65535